### PR TITLE
Feature/fend 1011 Добавить свойство для открытия по клику

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Added new tests based on React testing library
-- TourItem overlayBackgroundColor prop is removed. "tour-overlay" class with "fill" attribute used to change background color
+- TourItem: overlayBackgroundColor prop is removed. "tour-overlay" class with "fill" attribute used to change background color
 - Added "form" and "name" props checker for input components
 (Input, DateTimeInput, DateTimeInputRange, TextArea, AutoComplete, ButtonGroup, DropZone, FileDrop, MaskedInput, MultiSelect, NumericRange, CheckBox, Password, Switcher, NumericTextBox)
-- DropDown. Added prop interactionMode='click' to opening dropdown by click
+- DropDown: Added prop interactionMode='click' to opening dropdown by click
 - Added onEnterPress prop for handling keydown enter to AutoComplete, DropDownSelect, MultiSelect, DateRange, NumericRange, NumericTextBox components
 
 ## [0.25.0] - 2020-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - TourItem overlayBackgroundColor prop is removed. "tour-overlay" class with "fill" attribute used to change background color
 - Added "form" and "name" props checker for input components
 (Input, DateTimeInput, DateTimeInputRange, TextArea, AutoComplete, ButtonGroup, DropZone, FileDrop, MaskedInput, MultiSelect, NumericRange, CheckBox, Password, Switcher, NumericTextBox)
+- DropDown. Added prop interactionMode='click' to opening dropdown by click
 - Added onEnterPress prop for handling keydown enter to AutoComplete, DropDownSelect, MultiSelect, DateRange, NumericRange, NumericTextBox components
 
 ## [0.25.0] - 2020-07-02

--- a/demo/components/DropDown.tsx
+++ b/demo/components/DropDown.tsx
@@ -8,8 +8,9 @@ export const DropDown = () => {
     <L.Div _demoStory>
       <L.H4 _title>DropDown</L.H4>
       <br/>
-      <L.DropDown _more wrapperRender={({elementProps}: any) => <L.Button {...elementProps} />}>
-        <L.Span>Hello</L.Span>
+      {/* <L.Span _margin-top>Открытие по наведению</L.Span> */}
+      <L.DropDown _more wrapperRender={({elementProps}: any) => <L.Button {...elementProps}/>}>
+        <L.Span>Hello Blur</L.Span>
         <L.Ul _txtLeft>
           <L.Li _level2>
             <L.A>Мармелад</L.A>
@@ -25,6 +26,31 @@ export const DropDown = () => {
           </L.Li>
         </L.Ul>
       </L.DropDown>
+      <L.Span _marginLeft>default</L.Span>
+
+
+      <br />
+      <br/>
+
+      {/* <L.Span _margin-top>Открытие по клику</L.Span> */}
+      <L.DropDown _more interactionMode='click' wrapperRender={({elementProps}: any) => <L.Button {...elementProps}/>}>
+        <L.Span>Hello Click</L.Span>
+        <L.Ul _txtLeft>
+          <L.Li _level2>
+            <L.A>Мармелад</L.A>
+          </L.Li>
+          <L.Li _level2>
+            <L.A>Суфле</L.A>
+          </L.Li>
+          <L.Li _level2>
+            <L.A>Шоколад</L.A>
+          </L.Li>
+          <L.Li _level2>
+            <L.A>Кексики</L.A>
+          </L.Li>
+        </L.Ul>
+      </L.DropDown>
+      <L.Span _marginLeft>interactionMode='click'</L.Span>
 
       <br />
       <br />

--- a/leda/components/DropDown/DropDown.test.tsx
+++ b/leda/components/DropDown/DropDown.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import {
-  render, screen,
+  render, screen, fireEvent,
 } from '@testing-library/react';
 import { DropDown } from './index';
+// eslint-disable-next-line import/no-useless-path-segments
+import * as L from '../../../leda';
 
 describe('DropDown SNAPSHOTS', () => {
   it('should render', () => {
@@ -99,5 +101,21 @@ describe('DropDown ATTRIBUTES', () => {
     expect(screen.getByText('test').parentElement?.tagName).toEqual('DIV');
 
     expect(screen.getByText('test').parentElement?.className).toEqual('level-1');
+  });
+
+  describe('InteractionMode = "click"', () => {
+    it('should be opened by click on and closed by click outside', () => {
+      render((
+        <DropDown interactionMode="click" wrapperRender={({ elementProps }: any) => <L.Button {...elementProps} />}>
+          <L.Span>test</L.Span>
+        </DropDown>
+      ));
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(screen.getByRole('button')).toHaveClass('opened');
+
+      fireEvent.blur(screen.getByRole('button'));
+      expect(screen.getByRole('button')).not.toHaveClass('opened');
+    });
   });
 });

--- a/leda/components/DropDown/index.tsx
+++ b/leda/components/DropDown/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import {
   bindFunctionalRef, getClassNames, useTheme, useElement, useAdaptivePosition, useProps,
 } from '../../utils';
@@ -16,6 +17,7 @@ export const DropDown = React.forwardRef((props: DropDownProps, ref?: React.Ref<
     className,
     isOpen: isOpenProp,
     theme: themeProp,
+    interactionMode,
     wrapperRender,
     ...restProps
   } = useProps(props);
@@ -54,11 +56,20 @@ export const DropDown = React.forwardRef((props: DropDownProps, ref?: React.Ref<
     isOpen,
   });
 
+  const interaction = interactionMode === 'click'
+    ? {
+      onClick: () => setIsOpen(true),
+      onBlur: () => setIsOpen(false),
+    }
+    : {
+      onMouseOver: () => setIsOpen(true),
+      onMouseLeave: () => setIsOpen(false),
+    };
+
   return (
     <Wrapper
+      {...interaction}
       className={combinedClassNames}
-      onMouseOver={() => setIsOpen(true)}
-      onMouseLeave={() => setIsOpen(false)}
       {...restProps}
       ref={ref && ((component) => bindFunctionalRef(component, ref, component && {
         wrapper: component.wrapper || component,

--- a/leda/components/DropDown/types.ts
+++ b/leda/components/DropDown/types.ts
@@ -14,6 +14,8 @@ export interface DropDownProps extends React.HTMLAttributes<HTMLElement> {
   theme?: PartialGlobalDefaultTheme[typeof COMPONENTS_NAMESPACES.dropDown],
   /** Тег-обертка, при наведении на который, будет отображаться данный dropdown, по умолчанию <span> */
   wrapperRender?: (props: RenderEvent<DropDownProps>) => React.ReactNode,
+  /** Открытие по клику, по умолчанию открытие по наведению */
+  interactionMode?: 'click',
   /** Классы переданные через _ */
   [x: string]: unknown,
 }


### PR DESCRIPTION
Добавлено свойство interactionMode="click"
Чтобы у дропдауна появилась возможность открывать его по клику и закрывать по любой области вне дропдауна. Свойство не по умолчанию, опциональное.