### PR TITLE
FEND-948 [DatePicker] Bug Fixed with selecting date by press "enter" on isOpen mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- DateTimeInput. Bug fixed with selecting a date by keydown "enter" in component with prop "isOpen"
 
 
 ## [0.26.0] - 2020-07-15

--- a/leda/src/DateTimeInput/hooks.ts
+++ b/leda/src/DateTimeInput/hooks.ts
@@ -59,7 +59,7 @@ export const useDateTimeInputEffects = ({
 
 export const useDateTimeInputState = (props: DateTimeInputProps): [DateTimeInputState, React.Dispatch<AllActions>] => {
   const {
-    value: valueProp, format, min, max,
+    value: valueProp, format, min, max, isOpen,
   } = props;
 
   // если сегодняшняя дата за пределами min/max - открываем календарь с датой min или max
@@ -85,7 +85,7 @@ export const useDateTimeInputState = (props: DateTimeInputProps): [DateTimeInput
   };
   const [state, dispatch] = React.useReducer(stateReducer, initialState);
 
-  return [state, dispatch];
+  return [{ ...state, isOpen: isOpen ?? state.isOpen }, dispatch];
 };
 
 export const useCustomElements = (props: DateTimeInputProps, state: DateTimeInputState): CustomElements => {


### PR DESCRIPTION
Solved by providing isOpen prop into the state right after the initialization